### PR TITLE
no need for redirection for directories

### DIFF
--- a/lib/HTTP/Server/Brick.pm
+++ b/lib/HTTP/Server/Brick.pm
@@ -470,7 +470,12 @@ sub _render_directory {
 <a href="..">.. (Parent directory)</a>
 END_HEADER
 
-        $res->add_content("<a href=\"$_\">$_</a>\n") for map {s!.*/!!; $_} sort glob "$path/*";
+        for (sort glob "$path/*") {
+            my $is_directory = -d $_;
+            s!.*/!!;
+            $_ .= '/' if $is_directory;
+            $res->add_content("<a href=\"$_\">$_</a>\n");
+        }
 
         $res->add_content(<<END_FOOTER);
 </pre></blockquote>


### PR DESCRIPTION
Links to subdirectories lack a trailing '/' and this triggers a redirection when these links are clicked. This has the disadvantage of triggering a redirection to add the trailing slash, which is inefficient at best and distruptive in some cases (possibly because of some other bug between HSB and URI).

This change just adds a trailing slash to all directory items, so that clicking them does not trigger the redirection.
