### PR TITLE
fix test for perl >= 5.26.0 (POSIX::tmpnam is removed)

### DIFF
--- a/t/serving.t
+++ b/t/serving.t
@@ -14,6 +14,7 @@ use LWP;
 use LWP::UserAgent;
 use HTTP::Status;
 use POSIX qw(:sys_wait_h SIGHUP SIGKILL);
+use File::Temp qw(tempdir);
 
 my $port = $ENV{HSB_TEST_PORT} || 65432;
 my $host = $ENV{HSB_TEST_HOST} || '127.0.0.1';
@@ -84,8 +85,8 @@ sub run_tests {
   my $temp_text_file = 'foo.txt';
   my $temp_html_file = 'foo.html';
 
-  my $temp_dir = POSIX::tmpnam();
-  mkdir $temp_dir or die "Unable to create temp dir $temp_dir";
+  my $temp_dir = eval { tempdir(CLEANUP => 1) };
+  $@ and die "Unable to create temp dir: $@";
 
   {
       my $text_fh;
@@ -95,15 +96,6 @@ sub run_tests {
       my $html_fh;
       open($html_fh, ">$temp_dir/$temp_html_file") or die "Unable to write to temp file $temp_html_file";
       print $html_fh "<html><body><h1>Hi Dr Nick</h1></body></html>";
-  }
-
-  # clean up temp dirs
-  END {
-      no warnings 'closure';
-      
-      unlink "$temp_dir/$temp_text_file" if $temp_dir && $temp_text_file && -f "$temp_dir/$temp_text_file";
-      unlink "$temp_dir/$temp_html_file" if $temp_dir && $temp_html_file && -f "$temp_dir/$temp_html_file";
-      rmdir $temp_dir if $temp_dir && -d $temp_dir;
   }
 
   # no point testing these - they just return 1.


### PR DESCRIPTION
Hello.

fix test for perl >= 5.26.0 (POSIX::tmpnam is removerd)

Best Regards, Ilya Pavlov